### PR TITLE
MIDI-163: Variable record length training

### DIFF
--- a/gpt2/configs/gpt2_pretraining.yaml
+++ b/gpt2/configs/gpt2_pretraining.yaml
@@ -1,6 +1,5 @@
 defaults:
   - model: gpt2
-  - data: default
   - tokenizer: exponential
   - dataset: tokenized
   - lr: cosine_decay
@@ -26,7 +25,8 @@ eval_iters: 50
 training:
   prompt_masking: false
   context_size: 2048
-  notes_per_record: 128
+  min_notes_per_record: 32
+  max_notes_per_record: 128
   # What you want the model to see
   batch_size: 64
   # What can fit in a single GPU
@@ -48,5 +48,5 @@ system:
 logging:
   wandb_log: True
   wandb_entity: 'epr-labs'
-  wandb_project: 'piano-gpt'
+  wandb_project: 'piano-gpt-vlt'
   log_interval: 20

--- a/gpt2/configs/model/gpt2_530M.yaml
+++ b/gpt2/configs/model/gpt2_530M.yaml
@@ -1,6 +1,7 @@
-n_layer: 36
+# 536M
+n_layer: 32
 n_head: 20
-n_embd: 1280
+n_embd: 1180
 dropout: 0.0  # for pretraining 0 is good, for finetuning try 0.1+
 bias: false  # do we use bias inside LayerNorm and Linear layers?
-context_size: ${data.context_size}
+context_size: ${training.context_size}

--- a/gpt2/data/piano_dataset.py
+++ b/gpt2/data/piano_dataset.py
@@ -1,4 +1,5 @@
 import json
+from typing import NamedTuple
 
 import torch
 import numpy as np
@@ -11,8 +12,16 @@ from gpt2.data.dataset import MidiDataset
 from gpt2.data.musicality import MusicManager
 
 
+class PianoIndex(NamedTuple):
+    task_name: str
+    start_point: int
+    record_idx: int
+    n_notes: int
+
+
 class PianoDataset(MidiDataset):
     generation_token = "<GENAI>"
+    generation_end_token = "<EOGENAI>"
 
     def __init__(
         self,
@@ -20,7 +29,8 @@ class PianoDataset(MidiDataset):
         tokenizer: AwesomeMidiTokenizer | ExponentialTimeTokenizer,
         # TODO How can I find out what's the relation between *context_size* and *notes_per_record*?
         context_size: int,
-        notes_per_record: int,
+        max_notes_per_record: int,
+        min_notes_per_record: int,
         music_manager: MusicManager,
         piano_task_manager: PianoTaskManager,
         prompt_masking: bool = False,
@@ -32,7 +42,8 @@ class PianoDataset(MidiDataset):
         self.prompt_masking = prompt_masking
         self.context_size = context_size
         self.music_manager = music_manager
-        self.notes_per_record = notes_per_record
+        self.max_notes_per_record = max_notes_per_record
+        self.min_notes_per_record = min_notes_per_record
 
         self.piano_task_manager = piano_task_manager
         # TODO Maybe a .get_task(task_id) would be better for task management
@@ -44,7 +55,8 @@ class PianoDataset(MidiDataset):
     def __rich_repr__(self):
         yield "size", len(self)
         yield "n_midi_records", len(self.record_lengths)
-        yield "notes_per_record", self.notes_per_record
+        yield "max_notes_per_record", self.max_notes_per_record
+        yield "min_notes_per_record", self.min_notes_per_record
         yield "context_size", self.context_size
         yield "n_piano_tasks", len(self.piano_task_names)
         yield "prompt_masking", self.prompt_masking
@@ -56,41 +68,60 @@ class PianoDataset(MidiDataset):
         """
         # Each record in the input dataset offers a *record_length* number
         # of possible starting points to get a note subsequence with *notes_per_record*
-        record_lengths = np.array(self.dataset["n_notes"]) - self.notes_per_record + 1
+        record_lengths = np.array(self.dataset["n_notes"]) - self.max_notes_per_record + 1
+
+        # For every record we can have that many different subsequences with different lengths
+        self.n_duration_options = self.max_notes_per_record - self.min_notes_per_record
 
         # Records shorter than context are effectively discarded
         self.record_lengths = record_lengths.clip(min=0)
 
         # Calculate total dataset length
-        self.length = self.record_lengths.sum() * self.num_tasks
+        self.length = self.record_lengths.sum() * self.num_tasks * self.n_duration_options
 
     def __len__(self):
         # Return the total length of the dataset
         return self.length
 
-    def _index_to_record(self, idx: int) -> tuple[int, int, str]:
+    def _decode_piano_index(self, idx: int) -> PianoIndex:
         # Convert global index to record ID and start point within that record
         # First get the task number
         task_number = idx % self.num_tasks
         task_name = self.piano_task_names[task_number]
 
-        start_point = idx // self.num_tasks
-        for record_id, record_length in enumerate(self.record_lengths):
+        # Go to the second level index ...
+        idx_bis = idx // self.num_tasks
+
+        # ... and decode the number of notes for this record
+        n_notes = self.min_notes_per_record + (idx_bis % self.n_duration_options)
+
+        # ... and then decode the starting note idx
+        start_point = idx_bis // self.n_duration_options
+
+        for record_idx, record_length in enumerate(self.record_lengths):
             if start_point < record_length:
-                return record_id, start_point, task_name
+                piano_index = PianoIndex(
+                    task_name=task_name,
+                    start_point=start_point,
+                    record_idx=record_idx,
+                    n_notes=n_notes,
+                )
+                return piano_index
+
             start_point -= record_length
 
         raise IndexError("Index out of range")
 
     def __getitem__(self, idx: int) -> dict:
         # Get the record ID and start point for the given index
-        record_id, start_point, task_name = self._index_to_record(idx)
-        record = self.dataset[record_id]
+        # record_id, start_point, task_name = self._index_to_record(idx)
+        piano_index = self._decode_piano_index(idx)
+        record = self.dataset[piano_index.record_idx]
         piece_source = json.loads(record["source"])
 
         # Convert notes to a DataFrame and select the desired range
         notes_df = pd.DataFrame(record["notes"])
-        notes_df = notes_df.iloc[start_point : start_point + self.notes_per_record]
+        notes_df = notes_df.iloc[piano_index.start_point : piano_index.start_point + piano_index.n_notes]
 
         # Normalize start and end times
         offset = notes_df.start.min()
@@ -98,7 +129,7 @@ class PianoDataset(MidiDataset):
         notes_df.end = notes_df.end - offset
 
         # Break the music into prompt and target parts
-        piano_task = self.piano_task_manager.get_task(task_name=task_name)
+        piano_task = self.piano_task_manager.get_task(task_name=piano_index.task_name)
         piece_split = piano_task.prompt_target_split(notes_df=notes_df)
 
         # Encode prompt part ...
@@ -122,10 +153,16 @@ class PianoDataset(MidiDataset):
         target_token_ids = self.tokenizer.encode_notes_df(
             notes_df=piece_split.target_df,
         )
-        # TODO I think this should be a tokenizer-level special token, similar to <PAD>?
+
+        # This is to indicate the beginning of generation ...
         target_prefix_tokens = [self.generation_token]
         target_prefix_token_ids = self.tokenizer.encode_tokens(target_prefix_tokens)
-        answer_token_ids = target_prefix_token_ids + target_token_ids
+
+        # ... and this is for the end
+        target_finish_token = [self.generation_end_token]
+        target_finish_token_ids = self.tokenizer.encode_tokens(target_finish_token)
+
+        answer_token_ids = target_prefix_token_ids + target_token_ids + target_finish_token_ids
 
         # Join both input and output into a single sequence
         encoding = prompt_token_ids + answer_token_ids
@@ -158,9 +195,10 @@ class PianoDataset(MidiDataset):
 
         # Prepare the output dictionary
         out = {
-            "task": task_name,
+            "task": piano_index.task_name,
             "target_mask": target_mask,
-            "start_point": start_point,
+            "n_notes": piano_index.n_notes,
+            "start_point": piano_index.start_point,
             "piece_source": json.dumps(piece_source),
             "source_token_ids": source_token_ids,
             "target_token_ids": target_token_ids,

--- a/gpt2/setup/datasets.py
+++ b/gpt2/setup/datasets.py
@@ -135,7 +135,7 @@ def piano_task_setup(
     piano_task_manager = PianoTaskManager(tasks_config=tasks_config)
 
     special_tokens = piano_task_manager.get_special_tokens()
-    special_tokens += [PianoDataset.generation_token]
+    special_tokens += [PianoDataset.generation_token, PianoDataset.generation_end_token]
     tokenizer.add_special_tokens(special_tokens)
 
     datasets = create_piano_datasets(

--- a/gpt2/utils.py
+++ b/gpt2/utils.py
@@ -77,12 +77,13 @@ def create_tokenized_dataset(cfg: DictConfig, tokenizer: MidiTokenizer) -> Datas
 
 def create_augmented_dataset(cfg: DictConfig) -> Dataset:
     """Load raw hf dataset for piano tasks."""
-    return load_dataset(
+    dataset = load_dataset(
         path=to_absolute_path("./gpt2/midi_datasets/AugmentedDataset"),
         trust_remote_code=True,
         num_proc=cfg.system.data_workers,
         **OmegaConf.to_container(cfg.dataset),
     )
+    return dataset
 
 
 def create_next_token_datasets(
@@ -127,7 +128,8 @@ def create_piano_datasets(
         music_manager=music_manager,
         context_size=cfg.training.context_size,
         prompt_masking=cfg.training.prompt_masking,
-        notes_per_record=cfg.training.notes_per_record,
+        max_notes_per_record=cfg.training.max_notes_per_record,
+        min_notes_per_record=cfg.training.min_notes_per_record,
         piano_task_manager=piano_task_manager,
     )
 
@@ -137,10 +139,11 @@ def create_piano_datasets(
             dataset=split,
             tokenizer=tokenizer,
             music_manager=music_manager,
+            piano_task_manager=piano_task_manager,
             context_size=cfg.training.context_size,
             prompt_masking=cfg.training.prompt_masking,
-            notes_per_record=cfg.training.notes_per_record,
-            piano_task_manager=piano_task_manager,
+            max_notes_per_record=cfg.training.max_notes_per_record,
+            min_notes_per_record=cfg.training.min_notes_per_record,
         )
         for name, split in validation_splits.items()
     }

--- a/scripts/download_model.py
+++ b/scripts/download_model.py
@@ -30,7 +30,7 @@ def download_model(
 
 
 if __name__ == "__main__":
-    # python -m scripts.download_model -c 303M-pretraining-2025...pt -r epr-labs/piano-gpt -l tmp/
+    # python -m scripts.download_model -r epr-labs/piano-gpt -l tmp/ -c 303M-pretraining-2025...pt
     parser = argparse.ArgumentParser(description="Download a model checkpoint from HF repository")
     parser.add_argument("-c", "--checkpoint_filename", type=str, help="Path to the file")
     parser.add_argument("-r", "--repo_id", type=str, help="Huggingface repo id")

--- a/train_script.sh
+++ b/train_script.sh
@@ -1,14 +1,14 @@
 PYTHONPATH=. torchrun --nproc-per-node=4 -m gpt2.main \
     dataset=augmented_every \
     model_task=piano_task \
-    training.batch_size=96 \
+    training.batch_size=128 \
     training.microbatch_size=8 \
     lr=cosine_decay \
-    lr.warmup_iters=5000 \
+    lr.warmup_iters=10000 \
     lr.lr_decay_iters=300000 \
     lr.learning_rate=1e-4 \
     lr.min_lr=2e-5 \
     model=gpt2_medium \
     system.data_workers=128 \
     system.compile=true \
-    training.loss_masking=pretrianing
+    training.prompt_masking=false


### PR DESCRIPTION
- The model will now see records with different numbers of notes.
- Added a EOS token to mark the end of generation 

The effects on training models:

1. Increased `best_val_loss` from ~1.2 to ~1.4 for 300M 15G tokens (I think it's expected, model has to be more capable)
2. Some piano tasks seem to be better executed on OOD prompts, i.e. model actually adds 10 notes for the "unmask 10 notes" task

To recreate previous setup use config (to get `notes_per_record=N`):

```yaml
training.min_notes_per_record=N
training.max_notes_per_record=N + 1
```
