### PR TITLE
MIDI-164: Add the prompt practice dashboard from piano-generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Calculate PIANO metrics:
 python -m gpt2.piano_eval init_from=<checkpoint path>
 ```
 
+Launch the generation dashboard:
+
+```sh
+PYTHONPATH=. streamlit run dashboards/prompt_practice.py
+```
+
 ## Overview
 
 Piano-GPT is a project leveraging the GPT-2 architecture for generating and processing MIDI piano music. It introduces the PIANO (Performance Inference And Note Orchestration) dataset, a multi-task benchmark for voice and dynamic reconstruction in MIDI piano rolls.

--- a/dashboards/prompt_practice.py
+++ b/dashboards/prompt_practice.py
@@ -79,7 +79,6 @@ def main():
         # optional_special_tokens = list(dataset_tokens)
 
         piano_task_manager: PianoTaskManager = model_setup["piano_task_manager"]
-        generation_token = "<GENAI>"
 
         dataset_tokens = MusicManager().dataset_tokens
         dataset_token = st.selectbox(
@@ -88,11 +87,12 @@ def main():
             help="Choose from available special tokens to add to your prompt",
         )
 
-        piano_task_tokens = st.multiselect(
-            label="Select tokens defining a PIANO task:",
-            options=piano_task_manager.get_special_tokens(),
-            help="Choose from available special tokens to add to your prompt",
+        piano_task_name = st.selectbox(
+            label="Select PIANO task:",
+            options=piano_task_manager.list_task_names(),
+            help="Choose from tasks used during training",
         )
+        piano_task = piano_task_manager.get_task(piano_task_name)
 
         prompt_path = st.selectbox(
             label="select prompt file",
@@ -124,9 +124,12 @@ def main():
     model = model_setup["model"]
     tokenizer = model_setup["tokenizer"]
 
+    # TODO this dashboards tries hard to work both for next token prediction
+    # and for the piano task generations – we should probably have separate dashboards
+    generation_token = "<GENAI>" if run_config.model_task == "piano_task" else None
     composer_tokens = ["<BACH>", "<MOZART>", "<CHOPIN>", "<UNKNOWN_COMPOSER>"]
     for composer_token in composer_tokens:
-        pre_input_tokens = [dataset_token, composer_token] + piano_task_tokens
+        pre_input_tokens = [dataset_token, composer_token] + piano_task.prefix_tokens
 
         st.write("Pre-input tokens:", pre_input_tokens)
 

--- a/dashboards/prompt_practice.py
+++ b/dashboards/prompt_practice.py
@@ -1,0 +1,295 @@
+import os
+from glob import glob
+
+import torch
+import requests
+import pandas as pd
+import fortepyan as ff
+import streamlit as st
+import streamlit_pianoroll
+from omegaconf import OmegaConf
+from midi_tokenizers import ExponentialTimeTokenizer
+from piano_dataset.piano_tasks import PianoTaskManager
+
+from gpt2.model import GPT
+from gpt2.data.musicality import MusicManager
+from dashboards.utils import device_model_selection
+from dashboards.utils.components import download_button
+
+
+def main():
+    # See the readme to figure out how you can get this checkpoint
+    # checkpoint_path = "checkpoints/midi-gpt2-302M-subsequence-4096-ctx-2024-09-08-19-42last.pt"
+    device, checkpoint_path = device_model_selection()
+    st.write("Checkpoint:", checkpoint_path)
+    model_setup = load_cache_checkpoint(checkpoint_path, device=device)
+    run_config = model_setup["run_config"]
+
+    if run_config.model_task != "piano_task":
+        st.write(
+            (
+                "This dashboard is designed for the PIANO Task generations,"
+                "but your model was trained for something else"
+            )
+        )
+        return
+
+    st.write("Training settings:")
+    st.write(OmegaConf.to_container(run_config.training))
+
+    st.write("Training stats:")
+    st.write(model_setup["run_stats"])
+
+    with st.form("generation setup"):
+        random_seed = st.number_input(
+            label="random seed",
+            value=137,
+            max_value=100_000,
+            min_value=0,
+        )
+        max_new_tokens = st.number_input(
+            label="max new tokens",
+            min_value=64,
+            max_value=4096,
+            value=128,
+        )
+        temperature = st.number_input(
+            label="temperature",
+            min_value=0.0,
+            max_value=2.0,
+            value=1.0,
+            step=0.05,
+        )
+
+        speedup_factor = st.number_input(
+            label="speedup factor",
+            value=1.0,
+            min_value=0.3,
+            max_value=2.5,
+        )
+
+        # TODO: What would be a convenient way to manage prompts
+        # for a user? Definitely needs an upload
+        prompt_options = glob("tmp/prompts/*.mid") + [None]
+
+        # Composer tokens are iterated over later, so we don't want
+        # the user to add them here
+        # special_tokens = composer_tokens + dataset_tokens
+        # We have to make a copy or streamlit loops over with every change
+        # optional_special_tokens = list(dataset_tokens)
+
+        piano_task_manager: PianoTaskManager = model_setup["piano_task_manager"]
+        generation_token = "<GENAI>"
+
+        dataset_tokens = MusicManager().dataset_tokens
+        dataset_token = st.selectbox(
+            label="Select a dataset token:",
+            options=dataset_tokens,
+            help="Choose from available special tokens to add to your prompt",
+        )
+
+        piano_task_tokens = st.multiselect(
+            label="Select tokens defining a PIANO task:",
+            options=piano_task_manager.get_special_tokens(),
+            help="Choose from available special tokens to add to your prompt",
+        )
+
+        prompt_path = st.selectbox(
+            label="select prompt file",
+            options=prompt_options,
+            index=None,
+        )
+        pianoroll_apikey = st.text_input(
+            label="pianoroll apikey",
+            type="password",
+        )
+        _ = st.form_submit_button()
+
+    st.write(pianoroll_apikey)
+
+    if not prompt_path:
+        return
+
+    prompt_piece = ff.MidiPiece.from_file(prompt_path)
+
+    # TODO Remove inplace operations from fortepyan
+    prompt_piece.time_shift(-prompt_piece.df.start.min())
+
+    prompt_notes_df: pd.DataFrame = prompt_piece.df
+    prompt_notes_df.start /= speedup_factor
+    prompt_notes_df.end /= speedup_factor
+
+    streamlit_pianoroll.from_fortepyan(prompt_piece)
+
+    model = model_setup["model"]
+    tokenizer = model_setup["tokenizer"]
+
+    composer_tokens = ["<BACH>", "<MOZART>", "<CHOPIN>", "<UNKNOWN_COMPOSER>"]
+    for composer_token in composer_tokens:
+        pre_input_tokens = [dataset_token, composer_token] + piano_task_tokens
+
+        st.write("Pre-input tokens:", pre_input_tokens)
+
+        # Generator randomness comes from torch.multinomial, so we can make it
+        # fully deterministic by setting global torch random seed
+        for it in range(2):
+            local_seed = random_seed + it * 1000
+            st.write("Seed:", local_seed)
+            st.write("".join(pre_input_tokens))
+
+            # This acts as a caching key
+            generation_properties = {
+                "speedup_factor": speedup_factor,
+                "prompt_path": prompt_path,
+                "local_seed": local_seed,
+            }
+
+            prompt_notes_df, generated_notes = cache_generation(
+                prompt_notes_df=prompt_notes_df,
+                seed=local_seed,
+                _model=model,
+                _tokenizer=tokenizer,
+                device=device,
+                pre_input_tokens=pre_input_tokens,
+                generation_token=generation_token,
+                temperature=temperature,
+                max_new_tokens=max_new_tokens,
+                **generation_properties,
+            )
+
+            prompt_piece = ff.MidiPiece(prompt_notes_df)
+            generated_piece = ff.MidiPiece(generated_notes)
+
+            streamlit_pianoroll.from_fortepyan(prompt_piece, generated_piece)
+
+            if pianoroll_apikey:
+                # TODO: Add title and description control
+                make_proll_post = st.button(
+                    label="post to pianoroll.io",
+                    key=f"{it}-{composer_token}",
+                )
+                if make_proll_post:
+                    post_to_pianoroll(
+                        model_piece=generated_piece,
+                        prompt_piece=prompt_piece,
+                        pianoroll_apikey=pianoroll_apikey,
+                    )
+                    st.write("POSTED!")
+
+            out_piece = ff.MidiPiece(pd.concat([prompt_notes_df, generated_notes]))
+            # Allow download of the full MIDI with context
+            full_midi_path = f"tmp/tmp_{composer_token}_{local_seed}.mid"
+            out_piece.to_midi().write(full_midi_path)
+            with open(full_midi_path, "rb") as file:
+                st.markdown(
+                    download_button(
+                        object_to_download=file.read(),
+                        download_filename=full_midi_path.split("/")[-1],
+                        button_text="Download midi with context",
+                    ),
+                    unsafe_allow_html=True,
+                )
+            st.write("---")
+    os.unlink(full_midi_path)
+
+
+def post_to_pianoroll(
+    model_piece: ff.MidiPiece,
+    prompt_piece: ff.MidiPiece,
+    pianoroll_apikey: str,
+):
+    model_notes = model_piece.df.to_dict(orient="records")
+    prompt_notes_df = prompt_piece.df.to_dict(orient="records")
+
+    payload = {
+        "model_notes": model_notes,
+        "prompt_notes_df": prompt_notes_df,
+        "post_title": "GENAI",
+        "post_description": "My model did this!",
+    }
+
+    headers = {
+        "UserApiToken": pianoroll_apikey,
+    }
+    api_endpoint = "https://pianoroll.io/api/v1/generation_pianorolls"
+    r = requests.post(api_endpoint, headers=headers, json=payload)
+
+    st.write(r)
+
+
+@st.cache_data
+def cache_generation(
+    prompt_notes_df: pd.DataFrame,
+    seed: int,
+    _model,
+    _tokenizer,
+    pre_input_tokens: list[str],
+    generation_token: str = None,
+    device: str = "cuda",
+    max_new_tokens: int = 2048,
+    temperature: int = 1,
+    **kwargs,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    torch.random.manual_seed(seed)
+    with st.spinner("gpu goes brrrrrrrrrr"):
+        input_tokens = pre_input_tokens + _tokenizer.tokenize(prompt_notes_df)
+
+        # This goes after the prompt
+        if generation_token is not None:
+            input_tokens.append(generation_token)
+
+        input_token_ids = _tokenizer.encode_tokens(input_tokens)
+        input_token_ids = torch.tensor(input_token_ids).unsqueeze(0).to(device)
+
+        generated_token_ids = _model.generate_new_tokens(
+            idx=input_token_ids,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            top_k=None,
+        )
+        generated_token_ids = generated_token_ids.squeeze(0).cpu().numpy()
+        generated_notes = _tokenizer.decode(generated_token_ids)
+
+    return prompt_notes_df, generated_notes
+
+
+@st.cache_data
+def load_cache_checkpoint(checkpoint_path: str, device) -> dict:
+    # Load a pre-trained model
+    checkpoint = torch.load(
+        checkpoint_path,
+        weights_only=False,
+    )
+
+    run_config = checkpoint["run_config"]
+    model_cfg = checkpoint["model_cfg"]
+
+    tokenizer = ExponentialTimeTokenizer.from_dict(checkpoint["tokenizer_desc"])
+
+    model = GPT(
+        config=model_cfg,
+        vocab_size=tokenizer.vocab_size,
+        pad_token_id=tokenizer.pad_token_id,
+    )
+    state_dict = checkpoint["model"]
+    model.load_state(state_dict=state_dict)
+    model.to(device)
+
+    if run_config.model_task == "piano_task":
+        tasks_config = run_config.tasks
+        piano_task_manager = PianoTaskManager(tasks_config=tasks_config)
+    else:
+        piano_task_manager = None
+
+    # TODO Function is missnamed, this is not a checkpoint
+    return {
+        "model": model,
+        "tokenizer": tokenizer,
+        "run_config": run_config,
+        "run_stats": checkpoint["run_stats"],
+        "piano_task_manager": piano_task_manager,
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboards/utils/__init__.py
+++ b/dashboards/utils/__init__.py
@@ -1,0 +1,18 @@
+from glob import glob
+
+import torch
+import streamlit as st
+
+
+def device_model_selection():
+    with st.sidebar:
+        st.header("Model Configuration")
+        devices = [f"cuda:{it}" for it in range(torch.cuda.device_count())] + ["cpu", "mps"]
+        device = st.selectbox("Select Device", options=devices, help="Choose the device to run the model on")
+        checkpoint_path = st.selectbox(
+            "Select Checkpoint",
+            options=glob("tmp/checkpoints/*.pt"),
+            help="Choose the model checkpoint to use",
+        )
+
+    return device, checkpoint_path

--- a/dashboards/utils/components.py
+++ b/dashboards/utils/components.py
@@ -1,0 +1,81 @@
+import re
+import json
+import uuid
+import base64
+
+import pandas as pd
+
+
+def download_button(object_to_download, download_filename, button_text):
+    """
+    Generates a link to download the given object_to_download.
+    Params:
+    ------
+    object_to_download:  The object to be downloaded.
+    download_filename (str): filename and extension of file. e.g. mydata.csv,
+    some_txt_output.txt download_link_text (str): Text to display for download
+    link.
+    button_text (str): Text to display on download button (e.g. 'click here to download file')
+    pickle_it (bool): If True, pickle file.
+    Returns:
+    -------
+    (str): the anchor tag to download object_to_download
+    Examples:
+    --------
+    download_link(your_df, 'YOUR_DF.csv', 'Click to download data!')
+    download_link(your_str, 'YOUR_STRING.txt', 'Click to download text!')
+    """
+    if isinstance(object_to_download, bytes):
+        pass
+
+    elif isinstance(object_to_download, pd.DataFrame):
+        object_to_download = object_to_download.to_csv(index=False)
+
+    # Try JSON encode for everything else
+    else:
+        object_to_download = json.dumps(object_to_download)
+
+    try:
+        # some strings <-> bytes conversions necessary here
+        b64 = base64.b64encode(object_to_download.encode()).decode()
+
+    except AttributeError:
+        b64 = base64.b64encode(object_to_download).decode()
+
+    button_uuid = str(uuid.uuid4()).replace("-", "")
+    button_id = re.sub(r"\d+", "", button_uuid)
+
+    custom_css = f"""
+        <style>
+            #{button_id} {{
+                background-color: rgb(255, 255, 255);
+                color: rgb(38, 39, 48);
+                padding: 0.25em 0.38em;
+                position: relative;
+                text-decoration: none;
+                border-radius: 4px;
+                border-width: 1px;
+                border-style: solid;
+                border-color: rgb(230, 234, 241);
+                border-image: initial;
+            }}
+            #{button_id}:hover {{
+                border-color: rgb(246, 51, 102);
+                color: rgb(246, 51, 102);
+            }}
+            #{button_id}:active {{
+                box-shadow: none;
+                background-color: rgb(246, 51, 102);
+                color: white;
+                }}
+        </style> """
+
+    a_html = f"""
+    <a download="{download_filename}" id="{button_id}" href="data:file/txt;base64,{b64}">
+        {button_text}
+    </a>
+    <br></br>
+    """
+    button_html = custom_css + a_html
+
+    return button_html


### PR DESCRIPTION
Run the dashboard:

```sh
PYTHONPATH=. streamlit run dashboards/prompt_practice.py
```

Select a model checkpoint in the sidebar:

<img width="420" alt="image" src="https://github.com/user-attachments/assets/636c836e-2b34-4f91-a5a3-184b1b945725" />

Select a MIDI prompt file:

<img width="420" alt="image" src="https://github.com/user-attachments/assets/233dc439-b914-45fc-8ad9-46a9ba81440d" />

Select generation settings:

<img width="420" alt="image" src="https://github.com/user-attachments/assets/9476e7b2-5c18-4fee-bc47-53d1a12697f1" />

Loaded model will be used to generate ~10 samples with different composer tokens and different random seeds:

<img width="420" alt="image" src="https://github.com/user-attachments/assets/1a88421a-887c-4783-b0d2-7f34e66ca8d5" />

