### PR TITLE
MIDI-165: Add model tuning command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Resume training:
 python -m gpt2.main --config-name=resume_training checkpoint_path=</path/to/checkpoint.pt>
 ```
 
+Tune model:
+
+```sh
+python -m gpt2.main --config-name=model_tuning checkpoint_path=</path/to/checkpoint.pt>
+```
+
 Calculate PIANO metrics:
 
 ```sh

--- a/gpt2/configs/dataset/medium.yaml
+++ b/gpt2/configs/dataset/medium.yaml
@@ -1,7 +1,8 @@
 base_dataset_name: "epr-labs/maestro-sustain-v2"
 extra_datasets:
   - 'epr-labs/maestro-augmented'
-  - "epr-labs/piano-midi-de"
+  - 'epr-labs/giant-midi-augmented'
+  - 'epr-labs/piano-midi-de-augmented'
   - 'epr-labs/pianofor-ai-augmented'
   - 'epr-labs/imslp-augmented'
 pause_detection_threshold: 4

--- a/gpt2/configs/gpt2_pretraining.yaml
+++ b/gpt2/configs/gpt2_pretraining.yaml
@@ -1,7 +1,7 @@
 defaults:
   - model: gpt2
   - tokenizer: exponential
-  - dataset: tokenized
+  - dataset: small
   - lr: cosine_decay
   - optimizer: default
   - tasks: piano_default

--- a/gpt2/configs/model_tuning.yaml
+++ b/gpt2/configs/model_tuning.yaml
@@ -1,0 +1,22 @@
+command: tune
+
+checkpoint_path:
+
+# Using defaults so it's possible to get datasets by config name
+# It's awkward because to control the overrid of datasets from CLI you have to:
+#   dataset=my_dataset_config
+# But to control other parameters, you have to use overrides prefix:
+#   overrides.run_name_suffix=myrun overrides.model.dropout=0.5
+# etc.
+defaults:
+  - dataset: small
+  - tasks: top_line
+  - _self_
+
+overrides:
+  run_name_suffix: tuning-${now:%Y-%m-%d-%H-%M}
+  dataset: ${dataset}
+  tasks: ${tasks}
+
+  model:
+    dropout: 0.1

--- a/gpt2/configs/model_tuning.yaml
+++ b/gpt2/configs/model_tuning.yaml
@@ -18,5 +18,8 @@ overrides:
   dataset: ${dataset}
   tasks: ${tasks}
 
+  training:
+    prompt_masking: true
+
   model:
     dropout: 0.1

--- a/gpt2/configs/model_tuning.yaml
+++ b/gpt2/configs/model_tuning.yaml
@@ -9,10 +9,12 @@ checkpoint_path:
 #   overrides.run_name_suffix=myrun overrides.model.dropout=0.5
 # etc.
 defaults:
-  - dataset: small
+  - dataset: medium
   - tasks: top_line
   - _self_
 
+# TODO Might be better to get rid of the overrides field and treat
+# this whole config as such
 overrides:
   run_name_suffix: tuning-${now:%Y-%m-%d-%H-%M}
   dataset: ${dataset}

--- a/gpt2/configs/tasks/top_line.yaml
+++ b/gpt2/configs/tasks/top_line.yaml
@@ -1,0 +1,3 @@
+- class: TopLineMasking
+  param_range:
+    - n_repetitions: 1

--- a/gpt2/configs/tasks/top_line.yaml
+++ b/gpt2/configs/tasks/top_line.yaml
@@ -1,3 +1,7 @@
 - class: TopLineMasking
   param_range:
     - n_repetitions: 1
+
+- class: ShortNotesMasking
+  param_range:
+    - n_notes: 10

--- a/gpt2/main.py
+++ b/gpt2/main.py
@@ -12,8 +12,7 @@ def main(cfg: DictConfig):
     if cfg.command == "init":
         gpt2_train.training_from_scratch(cfg=cfg)
     elif cfg.command == "tune":
-        # train.tune(tune_cfg=cfg)
-        ...
+        gpt2_train.model_tuning(tune_cfg=cfg)
     elif cfg.command == "resume":
         gpt2_train.resume_training(resume_cfg=cfg)
     else:

--- a/gpt2/train.py
+++ b/gpt2/train.py
@@ -21,9 +21,12 @@ from gpt2.setup.backprop import BackpropSetup, setup_backprop
 
 
 def model_tuning(tune_cfg: DictConfig):
+    # Loading to CPU to avoid CUDA memory management and known torch issues:
+    # https://discuss.pytorch.org/t/gpu-memory-usage-increases-by-90-after-torch-load/9213/16
     checkpoint = torch.load(
         tune_cfg.checkpoint_path,
         weights_only=False,
+        map_location=torch.device("cpu"),
     )
 
     run_cfg: DictConfig = checkpoint["run_config"]

--- a/gpt2/train.py
+++ b/gpt2/train.py
@@ -4,8 +4,8 @@ import datetime
 
 import torch
 import wandb
-from omegaconf import DictConfig
 from hydra.utils import to_absolute_path
+from omegaconf import OmegaConf, DictConfig
 from torch.distributed import destroy_process_group
 from midi_tokenizers import ExponentialTimeTokenizer
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -18,6 +18,91 @@ from gpt2.setup.datasets import DatasetsSetup
 from gpt2.setup import logging as logging_setup
 from gpt2.setup import hardware as hardware_setup
 from gpt2.setup.backprop import BackpropSetup, setup_backprop
+
+
+def model_tuning(tune_cfg: DictConfig):
+    checkpoint = torch.load(
+        tune_cfg.checkpoint_path,
+        weights_only=False,
+    )
+
+    run_cfg: DictConfig = checkpoint["run_config"]
+
+    overrides_cfg = tune_cfg["overrides"]
+    print("Config overrides:")
+    print(OmegaConf.to_container(overrides_cfg, resolve=True))
+
+    # - omegaconf documentation is not very clear
+    # about what exactly is the behavior of .merge(*configs)
+    # but seems like it replaces the initial config fields
+    # with whatever is provided in the other config
+    # - we also have to resolve overrides before merging
+    # or else there can be recursive references
+    OmegaConf.resolve(overrides_cfg)
+    run_cfg = OmegaConf.merge(run_cfg, overrides_cfg)
+
+    device_setup = hardware_setup.setup_device(run_cfg)
+    print("Device setup:", device_setup)
+
+    # Load tokenizer
+    tokenizer_desc = checkpoint["tokenizer_desc"]
+    tokenizer = ExponentialTimeTokenizer.from_dict(tokenizer_desc)
+
+    # TODO vocab and padding info should be checkpointed
+    model_cfg = run_cfg.model
+    model = GPT(
+        config=model_cfg,
+        vocab_size=tokenizer.vocab_size,
+        pad_token_id=tokenizer.pad_token_id,
+    )
+    state_dict = checkpoint["model"]
+    model.load_state(state_dict=state_dict)
+    model.to(device_setup.device)
+
+    if run_cfg.system.compile:
+        print("compiling the model... (takes a ~minute)")
+        model = torch.compile(model)
+
+    backprop_setup = setup_backprop(
+        cfg=run_cfg,
+        model=model,
+        device_setup=device_setup,
+    )
+
+    if run_cfg.model_task == "next_token_prediction":
+        datasets_setup = data_setup.next_token_prediction_setup(
+            cfg=run_cfg,
+            tokenizer=tokenizer,
+            device_setup=device_setup,
+        )
+    elif run_cfg.model_task == "piano_task":
+        datasets_setup = data_setup.piano_task_setup(
+            cfg=run_cfg,
+            tokenizer=tokenizer,
+            device_setup=device_setup,
+        )
+
+    milion_params = model.get_num_params() / 1e6
+    run_name = f"{milion_params:.0f}M-" f"{run_cfg.run_name_suffix}"
+
+    # wrap model into DDP container
+    if device_setup.is_ddp:
+        model = DDP(model, device_ids=[device_setup.local_rank])
+
+    if device_setup.is_master_process:
+        logging_setup.wandb_init(
+            run_name=run_name,
+            cfg=run_cfg,
+        )
+
+    training_loop(
+        cfg=run_cfg,
+        model=model,
+        run_name=run_name,
+        device_setup=device_setup,
+        backprop_setup=backprop_setup,
+        datasets_setup=datasets_setup,
+    )
 
 
 def resume_training(resume_cfg: DictConfig):
@@ -35,7 +120,7 @@ def resume_training(resume_cfg: DictConfig):
     tokenizer = ExponentialTimeTokenizer.from_dict(tokenizer_desc)
 
     # TODO vocab and padding info should be checkpointed
-    model_cfg = checkpoint["model_cfg"]
+    model_cfg = run_cfg.model
     model = GPT(
         config=model_cfg,
         vocab_size=tokenizer.vocab_size,
@@ -83,6 +168,10 @@ def resume_training(resume_cfg: DictConfig):
 
     print("Resuming from:", run_stats)
 
+    # wrap model into DDP container
+    if device_setup.is_ddp:
+        model = DDP(model, device_ids=[device_setup.local_rank])
+
     training_loop(
         cfg=run_cfg,
         model=model,
@@ -112,7 +201,7 @@ def training_from_scratch(cfg: DictConfig):
 
     cfg.training.gradient_accumulation_steps = gradient_accumulation_steps
 
-    # TODO This manager should probably go to the dataset setup
+    # TODO This if could probably go to the dataset setup
     if cfg.model_task == "next_token_prediction":
         datasets_setup = data_setup.next_token_prediction_setup(
             cfg=cfg,

--- a/tune_script.sh
+++ b/tune_script.sh
@@ -1,0 +1,3 @@
+PYTHONPATH=. torchrun --nproc-per-node=4 -m gpt2.main \
+    --config-name=model_tuning \
+    checkpoint_path=tmp/checkpoints/303M-pretraining-2025-02-27-20-53-best.pt


### PR DESCRIPTION
- override dataset sources
- override piano tasks config

To tune a model run:

```sh
# Or DDP equivalent
python -m gpt2.main --config-name=model_tuning checkpoint_path=</path/to/checkpoint.pt>
```

Observations:
Run a single experiment with a dataset of 2 simple piano tasks: https://wandb.ai/epr-labs/piano-gpt-vlt/groups/303M-tuning-2025-03-03-12-06/

- took a long time before val loss improved, maybe LR setup should be hyperparam-tuned separately for model tuning